### PR TITLE
[Network] 프로젝트 색 정보로 색 비활성화

### DIFF
--- a/Teamply/Teamply/Network/API/AddProjectAPI.swift
+++ b/Teamply/Teamply/Network/API/AddProjectAPI.swift
@@ -9,20 +9,40 @@ import Moya
 
 final class AddProjectAPI {
     static let shared: AddProjectAPI = AddProjectAPI()
-    private let colorInfoProvider = MoyaProvider<AddProjectService>(plugins: [MoyaLoggingPlugin()])
+    private let colorInfoProvider = MoyaProvider<HomeService>(plugins: [MoyaLoggingPlugin()])
     private let createProjectProvider = MoyaProvider<AddProjectService>(plugins: [MoyaLoggingPlugin()])
     private init() { }
     
-    public private(set) var colorData: GeneralResponse<ColorInfoResponse>?
+    public private(set) var colorData: GeneralResponse<UserProjectResponse>?
     public private(set) var createResult: GeneralResponse<CreateProjectResponse>?
     
     // MARK: - Get
-    func getcolorInfo(completion: @escaping ((GeneralResponse<ColorInfoResponse>?) -> ())) {
-        colorInfoProvider.request(.getColorInfo) { result in
+//    func getcolorInfo(completion: @escaping ((GeneralResponse<ColorInfoResponse>?) -> ())) {
+//        colorInfoProvider.request(.getColorInfo) { result in
+//            switch result {
+//            case .success(let response):
+//                do {
+//                    self.colorData = try response.map(GeneralResponse<ColorInfoResponse>?.self)
+//                    guard let colorData = self.colorData else {
+//                        return
+//                    }
+//                    completion(colorData)
+//                } catch(let err) {
+//                    print(err.localizedDescription, 500)
+//                }
+//            case .failure(let err):
+//                print(err.localizedDescription)
+//                completion(nil)
+//            }
+//        }
+//    }
+    
+    func getcolorInfo(completion: @escaping ((GeneralResponse<UserProjectResponse>?) -> ())) {
+        colorInfoProvider.request(.getUserProject) { result in
             switch result {
             case .success(let response):
                 do {
-                    self.colorData = try response.map(GeneralResponse<ColorInfoResponse>?.self)
+                    self.colorData = try response.map(GeneralResponse<UserProjectResponse>?.self)
                     guard let colorData = self.colorData else {
                         return
                     }
@@ -36,7 +56,6 @@ final class AddProjectAPI {
             }
         }
     }
-    
     // MARK: - Post
     func createProject(param: CreateProjectRequest, completion: @escaping ((GeneralResponse<CreateProjectResponse>?, Error?) -> ())) {
         createProjectProvider.request(.postCreateProject(param: param)) { [weak self] response in

--- a/Teamply/Teamply/Network/API/AddProjectAPI.swift
+++ b/Teamply/Teamply/Network/API/AddProjectAPI.swift
@@ -9,12 +9,35 @@ import Moya
 
 final class AddProjectAPI {
     static let shared: AddProjectAPI = AddProjectAPI()
+    private let colorInfoProvider = MoyaProvider<AddProjectService>(plugins: [MoyaLoggingPlugin()])
     private let createProjectProvider = MoyaProvider<AddProjectService>(plugins: [MoyaLoggingPlugin()])
     private init() { }
     
+    public private(set) var colorData: GeneralResponse<ColorInfoResponse>?
     public private(set) var createResult: GeneralResponse<CreateProjectResponse>?
     
     // MARK: - Get
+    func getColorInfo(completion: @escaping ((GeneralResponse<ColorInfoResponse>?) -> ())) {
+        colorInfoProvider.request(.getColorInfo) { result in
+            switch result {
+            case .success(let response):
+                do {
+                    self.colorData = try response.map(GeneralResponse<ColorInfoResponse>?.self)
+                    guard let colorData = self.colorData else {
+                        return
+                    }
+                    completion(colorData)
+                } catch(let err) {
+                    print(err.localizedDescription, 500)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+    
+    // MARK: - Post
     
     func createProject(param: CreateProjectRequest, completion: @escaping ((GeneralResponse<CreateProjectResponse>?, Error?) -> ())) {
         createProjectProvider.request(.postCreateProject(param: param)) { [weak self] response in

--- a/Teamply/Teamply/Network/API/AddProjectAPI.swift
+++ b/Teamply/Teamply/Network/API/AddProjectAPI.swift
@@ -17,7 +17,7 @@ final class AddProjectAPI {
     public private(set) var createResult: GeneralResponse<CreateProjectResponse>?
     
     // MARK: - Get
-    func getColorInfo(completion: @escaping ((GeneralResponse<ColorInfoResponse>?) -> ())) {
+    func getcolorInfo(completion: @escaping ((GeneralResponse<ColorInfoResponse>?) -> ())) {
         colorInfoProvider.request(.getColorInfo) { result in
             switch result {
             case .success(let response):
@@ -38,7 +38,6 @@ final class AddProjectAPI {
     }
     
     // MARK: - Post
-    
     func createProject(param: CreateProjectRequest, completion: @escaping ((GeneralResponse<CreateProjectResponse>?, Error?) -> ())) {
         createProjectProvider.request(.postCreateProject(param: param)) { [weak self] response in
             switch response {

--- a/Teamply/Teamply/Network/Base/NetworkConstant.swift
+++ b/Teamply/Teamply/Network/Base/NetworkConstant.swift
@@ -14,6 +14,6 @@ struct NetworkConstant {
                                  "Authorization": NetworkConstant.accessToken,
                                  "Refresh": NetworkConstant.refreshToken]
     
-    static var accessToken = "'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzcsImhhc2giOiI4MjgyZDhmMWIwODA3YjdkNDliOCIsImlwIjozNTU1NTUyODM0LCJpYXQiOjE2NzYzMDU2MTYsImV4cCI6MTY3NjM5MjAxNn0.ZYvEJIL23gzx0lvPvM1wr52r9rDMkAi4J-5ywJG5QRU'"
-    static var refreshToken = "'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2NzYzMDU2MTYsImV4cCI6MTY3ODEyMDAxNn0.W7UyFIBNsra8HSitfYUTpynIxzRnxywY_PVgeV45lnc'"
+    static var accessToken = "'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaGFzaCI6ImFhNjAwYmIxMzgxN2ZiMmExYjdmIiwiaXAiOjM1NTU1NTI4MzQsImlhdCI6MTY3NjM2OTUwOSwiZXhwIjoxNjc2NDU1OTA5fQ.rDAkkiSy9XjBPC0Lz9AdYNcth4E3NfnmQON8xE2ymMA'"
+    static var refreshToken = "'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2NzYzNjk1MDksImV4cCI6MTY3ODE4MzkwOX0.lxd46I8vhAERASeFC1_2W3YhdQJx-LJr6krawszU0-I'"
 }

--- a/Teamply/Teamply/Network/Base/URLConstant.swift
+++ b/Teamply/Teamply/Network/Base/URLConstant.swift
@@ -13,12 +13,12 @@ struct URLConstant {
     
     static let baseURL = "http://ec2-3-36-54-148.ap-northeast-2.compute.amazonaws.com"
     
-    static let signUp = "/user/signup"          //회원가입
-    static let login = "/user/login"            //로그인
+    static let signUp = "/user/signup"                  //회원가입
+    static let login = "/user/login"                    //로그인
     
-    static let userInto = "/user/my/account"    //개인 정보
-    static let userProject = "/project/my"      //개인 프로젝트
+    static let userInto = "/user/my/account"            //개인 정보
+    static let userProject = "/project/my"              //개인 프로젝트
+    static let userColorInfo = "/project/my/color"      //개인 프로젝트 색상 정보
     
-    static let createProject = "/project"       //프로젝트 생성
-
+    static let createProject = "/project"               //프로젝트 생성
 }

--- a/Teamply/Teamply/Network/Model/AddProjectModel/ColorInfoResponse.swift
+++ b/Teamply/Teamply/Network/Model/AddProjectModel/ColorInfoResponse.swift
@@ -1,0 +1,22 @@
+//
+//  ColorInfoResponse.swift
+//  Teamply
+//
+//  Created by 아라 on 2023/02/14.
+//
+
+import Foundation
+
+struct ColorInfoResponse: Codable {
+    let isSuccess: Bool
+    let code: Int
+    let data: Result
+}
+
+struct Result: Codable {
+    let result: [Color]
+}
+
+struct Color: Codable {
+    let color: String
+}

--- a/Teamply/Teamply/Network/Model/AddProjectModel/ColorInfoResponse.swift
+++ b/Teamply/Teamply/Network/Model/AddProjectModel/ColorInfoResponse.swift
@@ -8,12 +8,6 @@
 import Foundation
 
 struct ColorInfoResponse: Codable {
-    let isSuccess: Bool
-    let code: Int
-    let data: Result
-}
-
-struct Result: Codable {
     let result: [Color]
 }
 

--- a/Teamply/Teamply/Network/Model/AddProjectModel/ColorInfoResponse.swift
+++ b/Teamply/Teamply/Network/Model/AddProjectModel/ColorInfoResponse.swift
@@ -8,9 +8,5 @@
 import Foundation
 
 struct ColorInfoResponse: Codable {
-    let result: [Color]
-}
-
-struct Color: Codable {
-    let color: String
+    let result: [String]
 }

--- a/Teamply/Teamply/Network/Model/AddProjectModel/ColorInfoResponse.swift
+++ b/Teamply/Teamply/Network/Model/AddProjectModel/ColorInfoResponse.swift
@@ -8,5 +8,12 @@
 import Foundation
 
 struct ColorInfoResponse: Codable {
-    let result: [String]
+    let isSuccess: Bool
+    let code: Int
+    let data: Color
+}
+
+// MARK: - DataClass
+struct Color: Codable {
+    let colors: [String]
 }

--- a/Teamply/Teamply/Network/Model/HomeModel/UserInfoResponse.swift
+++ b/Teamply/Teamply/Network/Model/HomeModel/UserInfoResponse.swift
@@ -14,17 +14,16 @@ struct UserInfoResponse: Codable {
 // MARK: - Result
 struct Info: Codable {
     let userID: Int
-    let userName, userEmail, userPw: String
-    let accessConsent, serviceConsent, createIP, updateIP: Int
-    let activate, isResigned: Int
+    let userName, userEmail: String
+    let ip, activate, isResigned: Int
     let createAt, updateAt: String
 
     enum CodingKeys: String, CodingKey {
         case userID = "user_id"
         case userName = "user_name"
         case userEmail = "user_email"
-        case userPw = "user_pw"
-        case accessConsent, serviceConsent, createIP, updateIP, activate
+        case ip = "IP"
+        case activate
         case isResigned = "is_resigned"
         case createAt, updateAt
     }

--- a/Teamply/Teamply/Network/Model/HomeModel/UserProjectResponse.swift
+++ b/Teamply/Teamply/Network/Model/HomeModel/UserProjectResponse.swift
@@ -12,18 +12,18 @@ struct UserProjectResponse: Codable {
 }
 
 struct ProjectInfo: Codable {
-    let projId: Int
-    let title: String
+    let projectId: Int
+    let title, contents: String
     let headcount: Int
-    let startAt, endAt, contents: String
+    let startDate, endDate, color: String
     
     enum CodingKeys: String, CodingKey {
-        case projId = "proj_id"
+        case projectId = "proj_id"
         case title = "proj_name"
-        case headcount = "proj_headcount"
-        case startAt = "proj_startAt"
-        case endAt = "proj_endAt"
+        case headcount = "proj_realcount"
+        case startDate = "startAt"
+        case endDate = "endAt"
         case contents = "proj_contents"
-        //case color = "proj_color"
+        case color
     }
 }

--- a/Teamply/Teamply/Network/Service/AddProjectService.swift
+++ b/Teamply/Teamply/Network/Service/AddProjectService.swift
@@ -9,7 +9,6 @@ import Moya
 
 enum AddProjectService {
     case postCreateProject(param: CreateProjectRequest)
-    
     case getColorInfo
 }
 
@@ -27,7 +26,8 @@ extension AddProjectService: BaseTargetType {
         switch self {
         case .getColorInfo:
             return .get
-        default: return .post
+        case .postCreateProject(_):
+            return .post
         }
     }
     

--- a/Teamply/Teamply/Network/Service/AddProjectService.swift
+++ b/Teamply/Teamply/Network/Service/AddProjectService.swift
@@ -9,6 +9,8 @@ import Moya
 
 enum AddProjectService {
     case postCreateProject(param: CreateProjectRequest)
+    
+    case getColorInfo
 }
 
 extension AddProjectService: BaseTargetType {
@@ -16,11 +18,15 @@ extension AddProjectService: BaseTargetType {
         switch self {
         case .postCreateProject:
             return URLConstant.createProject
+        case .getColorInfo:
+            return URLConstant.userColorInfo
         }
     }
     
     var method: Moya.Method {
         switch self {
+        case .getColorInfo:
+            return .get
         default: return .post
         }
     }
@@ -29,6 +35,8 @@ extension AddProjectService: BaseTargetType {
         switch self {
         case .postCreateProject(let param):
             return .requestJSONEncodable(param)
+        case .getColorInfo:
+            return .requestPlain
         }
     }
     

--- a/Teamply/Teamply/Screen/Home/createTeamProject/selectColorViewController.swift
+++ b/Teamply/Teamply/Screen/Home/createTeamProject/selectColorViewController.swift
@@ -28,7 +28,8 @@ class selectColorViewController: UIViewController {
     @IBOutlet weak var colorStactView: UIStackView!
     
     // MARK: - Properties
-    let colors: [UIColor] = [.gray2!, .team1!, .team2!, .team3!, .team4!, .team5!, .team6!]
+    var colors: [UIColor] = []
+    var colorData: [String] = []
     var index = 0
     var colorHandler: ((UIColor) -> ())?
     let checkImage: UIImageView = {
@@ -42,9 +43,12 @@ class selectColorViewController: UIViewController {
     // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        getColorInfo()
         setInit()
-        viewInit()
         borderInit()
+        availableColorInit()
+        setViewAvailable()
+        colorViewInit()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -67,14 +71,7 @@ class selectColorViewController: UIViewController {
         selectButton.makeRound(radius: 10)
     }
     
-    func viewInit() {
-        team1ColorView.backgroundColor = .team1
-        team2ColorView.backgroundColor = .team2
-        team3ColorView.backgroundColor = .team3
-        team4ColorView.backgroundColor = .team4
-        team5ColorView.backgroundColor = .team5
-        team6ColorView.backgroundColor = .team6
-        
+    func borderInit() {
         border1View.backgroundColor = .basic1
         border2View.backgroundColor = .basic1
         border3View.backgroundColor = .basic1
@@ -82,22 +79,6 @@ class selectColorViewController: UIViewController {
         border5View.backgroundColor = .basic1
         border6View.backgroundColor = .basic1
         
-        team1ColorView.makeRound(radius: 5)
-        team2ColorView.makeRound(radius: 5)
-        team3ColorView.makeRound(radius: 5)
-        team4ColorView.makeRound(radius: 5)
-        team5ColorView.makeRound(radius: 5)
-        team6ColorView.makeRound(radius: 5)
-        
-        team1ColorView.isUserInteractionEnabled = true
-        team2ColorView.isUserInteractionEnabled = true
-        team3ColorView.isUserInteractionEnabled = true
-        team4ColorView.isUserInteractionEnabled = true
-        team5ColorView.isUserInteractionEnabled = true
-        team6ColorView.isUserInteractionEnabled = true
-    }
-    
-    func borderInit() {
         border1View.makeRound(radius: 5)
         border2View.makeRound(radius: 5)
         border3View.makeRound(radius: 5)
@@ -118,6 +99,66 @@ class selectColorViewController: UIViewController {
         border4View.layer.borderColor = UIColor.basic1?.cgColor
         border5View.layer.borderColor = UIColor.basic1?.cgColor
         border6View.layer.borderColor = UIColor.basic1?.cgColor
+    }
+    
+    func colorViewInit() {
+        var colorView: UIView!
+        for c in colors {
+            switch c {
+            case .team1! :
+                colorView = team1ColorView
+                break
+            case .team2! :
+                colorView = team2ColorView
+                break
+            case .team3! :
+                colorView = team3ColorView
+                break
+            case .team4! :
+                colorView = team4ColorView
+                break
+            case .team5! :
+                colorView = team5ColorView
+                break
+            case .team6! :
+                colorView = team6ColorView
+                break
+            default:
+                break
+            }
+            colorView.backgroundColor = .gray0
+            colorView.makeRound(radius: 5)
+            colorView.isUserInteractionEnabled = false
+        }
+    }
+    
+    func availableColorInit() {
+        team1ColorView.backgroundColor = .team1
+        team1ColorView.makeRound(radius: 5)
+        
+        team2ColorView.backgroundColor = .team2
+        team2ColorView.makeRound(radius: 5)
+        
+        team3ColorView.backgroundColor = .team3
+        team3ColorView.makeRound(radius: 5)
+        
+        team4ColorView.backgroundColor = .team4
+        team4ColorView.makeRound(radius: 5)
+        
+        team5ColorView.backgroundColor = .team5
+        team5ColorView.makeRound(radius: 5)
+        
+        team6ColorView.backgroundColor = .team6
+        team6ColorView.makeRound(radius: 5)
+    }
+    
+    func setViewAvailable() {
+        team1ColorView.isUserInteractionEnabled = true
+        team2ColorView.isUserInteractionEnabled = true
+        team3ColorView.isUserInteractionEnabled = true
+        team4ColorView.isUserInteractionEnabled = true
+        team5ColorView.isUserInteractionEnabled = true
+        team6ColorView.isUserInteractionEnabled = true
     }
     
     func setBorderView(idx: Int) {
@@ -152,7 +193,6 @@ class selectColorViewController: UIViewController {
             borderView = border6View
             break
         default:
-            borderInit()
             break
         }
         borderView.layer.borderColor = colorView.backgroundColor?.cgColor
@@ -165,6 +205,12 @@ class selectColorViewController: UIViewController {
             checkImage.widthAnchor.constraint(equalToConstant: 19.38),
             checkImage.heightAnchor.constraint(equalToConstant: 12.92),
         ])
+    }
+    
+    func StringToUIColor() {
+        for c in colorData {
+            colors.append(UIColor(named: c)!)
+        }
     }
     
     // MARK: - IBAction
@@ -197,5 +243,17 @@ class selectColorViewController: UIViewController {
     @IBAction func team6ColorTap(_ sender: UITapGestureRecognizer) {
         index = 6
         setBorderView(idx: index)
+    }
+}
+
+extension selectColorViewController {
+    func getColorInfo() {
+        AddProjectAPI.shared.getcolorInfo { [weak self] infoData in
+            guard let infoData = infoData else { return }
+            let info = infoData.data?.result
+            self?.colorData = info!
+            self?.StringToUIColor()
+            print(info!)
+        }
     }
 }

--- a/Teamply/Teamply/Screen/Home/createTeamProject/selectColorViewController.swift
+++ b/Teamply/Teamply/Screen/Home/createTeamProject/selectColorViewController.swift
@@ -251,7 +251,7 @@ extension selectColorViewController {
         AddProjectAPI.shared.getcolorInfo { [weak self] infoData in
             guard let infoData = infoData else { return }
             let info = infoData.data?.result
-            self?.colorData = info!
+            let colorData = info
             self?.StringToUIColor()
             print(info!)
         }

--- a/Teamply/Teamply/Screen/Home/createTeamProject/selectColorViewController.swift
+++ b/Teamply/Teamply/Screen/Home/createTeamProject/selectColorViewController.swift
@@ -30,8 +30,10 @@ class selectColorViewController: UIViewController {
     // MARK: - Properties
     var colors: [UIColor] = []
     var colorData: [String] = []
+    var projectInfo: [ProjectInfo] = []
     var index = 0
     var colorHandler: ((UIColor) -> ())?
+    var selectColor: UIColor!
     let checkImage: UIImageView = {
         let check = UIImageView()
         
@@ -45,10 +47,6 @@ class selectColorViewController: UIViewController {
         super.viewDidLoad()
         getColorInfo()
         setInit()
-        borderInit()
-        availableColorInit()
-        setViewAvailable()
-        colorViewInit()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -211,49 +209,67 @@ class selectColorViewController: UIViewController {
         for c in colorData {
             colors.append(UIColor(named: c)!)
         }
+        borderInit()
+        availableColorInit()
+        setViewAvailable()
+        colorViewInit()
+    }
+    
+    func setProjectColors() {
+        for p in projectInfo {
+            colorData.append(p.color)
+        }
+        StringToUIColor()
     }
     
     // MARK: - IBAction
     @IBAction func selectProjectColor(_ sender: Any) {
-        colorHandler?(self.colors[index])
-        self.presentingViewController?.dismiss(animated: true)
+        if selectColor != nil {
+            colorHandler?(self.selectColor)
+            self.presentingViewController?.dismiss(animated: true)
+        }
     }
     
     // MARK: - Gesture
     @IBAction func team1ColorTap(_ sender: UITapGestureRecognizer) {
         index = 1
         setBorderView(idx: index)
+        selectColor = .team1
     }
     @IBAction func team2ColorTap(_ sender: UITapGestureRecognizer) {
         index = 2
         setBorderView(idx: index)
+        selectColor = .team2
     }
     @IBAction func team3ColorTap(_ sender: UITapGestureRecognizer) {
         index = 3
         setBorderView(idx: index)
+        selectColor = .team3
     }
     @IBAction func team4ColorTap(_ sender: UITapGestureRecognizer) {
         index = 4
         setBorderView(idx: index)
+        selectColor = .team4
     }
     @IBAction func team5ColorTap(_ sender: UITapGestureRecognizer) {
         index = 5
         setBorderView(idx: index)
+        selectColor = .team5
     }
     @IBAction func team6ColorTap(_ sender: UITapGestureRecognizer) {
         index = 6
         setBorderView(idx: index)
+        selectColor = .team6
     }
 }
 
 extension selectColorViewController {
     func getColorInfo() {
-        AddProjectAPI.shared.getcolorInfo { [weak self] infoData in
-            guard let infoData = infoData else { return }
+        AddProjectAPI.shared.getcolorInfo { [weak self] colorData in
+            guard let infoData = colorData else { return }
             let info = infoData.data?.result
-            let colorData = info
-            self?.StringToUIColor()
-            print(info!)
+            self?.projectInfo = info!
+            self?.setProjectColors()
         }
     }
 }

--- a/Teamply/Teamply/Screen/Home/mainHome/HomeViewController.swift
+++ b/Teamply/Teamply/Screen/Home/mainHome/HomeViewController.swift
@@ -246,8 +246,8 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSour
             cell.titleLabel.text = projectInfo.title
             cell.contentLabel.text = projectInfo.contents
             cell.headCount = projectInfo.headcount
-            let start = projectInfo.startAt
-            let end = projectInfo.endAt
+            let start = projectInfo.startDate
+            let end = projectInfo.endDate
             cell.termLabel.text = start+"-"+end
             cell.setProjects()
         }


### PR DESCRIPTION
## 🚀관련 이슈
- close #55

## ✨작업 내용
- 프로젝트 추가시 이미 있는 프로젝트의 색은 비활성화 시켜서 선택 못하도록

## 📸 스크린샷
- 

## 📝참고 사항
- 색상 정보 API 연동이 안돼서 우선 개인 프로젝트 정보 API로 구현
